### PR TITLE
RFC: Add ignore directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ console.log(schema.getQueryType().toString())
 
 ```
 
+Create a schema using promises, and then log out the generated `.graphql` contents:
+
+```js
+const graphql = require('graphql')
+const loader = require('@creditkarma/graphql-loader')
+
+loader.loadSchema('./schema/*.graphql').then((schema) => {
+  console.log(graphql.printSchema(schema))
+}).catch(err => console.log(err))
+```
+
 ## Development
 
 Install dependencies with

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Install dependencies with
 
 ```sh
 npm install
-npm run typings
 npm install graphql@^0.8.0
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ Install dependencies with
 ```sh
 npm install
 npm run typings
+npm install graphql@^0.8.0
 ```
+
+The `graphql` package is needed for tests to succeed, but is only included as a peer dependency.
 
 ### Build
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ const loadSchema: ILoadSchemaFunc = (pattern: string, callback?: ISchemaCallback
   return new Promise((resolve, reject) => {
     getGlob(pattern)
       .then((fileNames) => readAllFiles(fileNames))
-      .then((fileContentArr) => fileContentArr.join(""))
+      .then((fileContentArr) => fileContentArr.join("\n"))
       .then((schemaFile) => parseSchema(schemaFile))
       .then((schema) => callback ? callback(null, schema) : resolve(schema))
       .catch((err) => callback ? callback(err, null) : reject(err))

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,19 +24,11 @@ export interface ILoadSchemaFunc {
 const loadSchema: ILoadSchemaFunc = (pattern: string, callback?: ISchemaCallback): Promise<GraphQLSchema> => {
   return new Promise((resolve, reject) => {
     getGlob(pattern)
-      .then((files) => makeSchema(files))
+      .then((fileNames) => readAllFiles(fileNames))
+      .then((fileContentArr) => fileContentArr.join(""))
       .then((schemaFile) => parseSchema(schemaFile))
       .then((schema) => callback ? callback(null, schema) : resolve(schema))
       .catch((err) => callback ? callback(err, null) : reject(err))
-  })
-}
-
-function makeSchema(fileNames: string[]): Promise<string> {
-  const promises = fileNames.map(readFile)
-  return Promise.all( promises ).then((fileContentArr: string[]) => {
-    return fileContentArr.join()
-  }).catch((err) => {
-    throw err
   })
 }
 
@@ -55,6 +47,10 @@ function getGlob(pattern: string): Promise<string[]> {
       }
     })
   })
+}
+
+function readAllFiles(fileNames: string[]): Promise<string[]> {
+  return Promise.all(fileNames.map(readFile))
 }
 
 function readFile(fileName: string): Promise<string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ const loadSchema: ILoadSchemaFunc = (pattern: string, callback?: ISchemaCallback
   return new Promise((resolve, reject) => {
     getGlob(pattern)
       .then((fileNames) => readAllFiles(fileNames))
+      .then((fileContentArr) => filterIgnoredFiles(fileContentArr))
       .then((fileContentArr) => fileContentArr.join("\n"))
       .then((schemaFile) => parseSchema(schemaFile))
       .then((schema) => callback ? callback(null, schema) : resolve(schema))
@@ -46,6 +47,13 @@ function getGlob(pattern: string): Promise<string[]> {
         resolve(files)
       }
     })
+  })
+}
+
+function filterIgnoredFiles(files: string[]): string[] {
+  return files.filter((file) => {
+    let firstLine = file.split("\n", 1)[0]
+    return firstLine !== "#ignore" && firstLine !== "# ignore"
   })
 }
 


### PR DESCRIPTION
Hi!

Firstly, this tool is really useful, it's enabled me to quickly setup our infrastructure for working with a `schema` directory full of `.graphql` files.

This pull request implements a few things that I ran into whilst getting started. These are just some thoughts, but I think they're worthwhile sharing, hence this pull request.

The main feature being added here is the ability to mark `.graphql` files as ignored, such that you can start adding a few scaffolding files for interfaces you know you will have, without having to implement those interfaces. Simply make the first line of the source file read as `#ignore` or `# ignore`, and the file will be filtered from the output sent to `graphql-js`

The second feature is a small improvement to the debugging experience. Previously, you may receive an error back that referenced a line in the source of your graphql files, however, this line would be shown as:

```
}type foo {
```

When really, what you have is the `}` in one file, and `type foo {` in the file with the error. This second feature is to simply join the input files with newlines, which means we get the exact line we wrote as the line in the error message.

I've also fixed up a few things in the README, which I ran into whilst trying to develop on this package locally. 