### PR TITLE
GraphQL modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,16 @@ GraphQL modules are comprised of a document node and resolvers to provide away t
 a GraphQL server into stand alone Node.js modules.  These modules expose a DocumentNode because
 document nodes are valid GraphQL segments that are not required to be a complete valid schema.
 
-It is required that the combination of GraphQLModules passed in results in a completely valid GraphQLSchema.
+It is required that the combination of GraphQLModules results in a completely valid GraphQLSchema.
 
 ```js
+const modules = [
+  () => loadDocument('./fixtures/user/**/*.graphql').then((document) => ({ document, resolvers: {}})),
+  () => loadDocument('./fixtures/swapi/**/*.graphql').then((document) => ({ document, resolvers: {}})),
+]
+executableSchemaFromModules(modules).then((schema) => {
+  console.log(schema.getQueryType().toString())
+})
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ console.log(schema.getQueryType().toString())
 
 ```
 
+## executableSchemaFromModules
+
+Given an array of GraphQL Modules or functions that returns a GraphQL Module or Promise,
+merge the documents and resolvers together and return an executable GraphQL Schema
+
+GraphQL modules are comprised of a document node and resolvers to provide away to decompose
+a GraphQL server into stand alone Node.js modules.  These modules expose a DocumentNode because
+document nodes are valid GraphQL segments that are not required to be a complete valid schema.
+
+It is required that the combination of GraphQLModules passed in results in a completely valid GraphQLSchema.
+
+```js
+
+```
+
 ## loadDocument
 
 Given a GLOB pattern, load the matching files, combine them together and return a GraphQL AST in
@@ -87,8 +102,8 @@ loader.loadDocument('./schema/*.graphql').then((doc) => {
 ## combineDocuments
 
 Given an array of DocumentNodes, merge them together and return a GraphQLSchema
-* Any duplicate Type definitions will be merged by concating their fields
-* Any duplicate Schema definitions will be merged by concating their operations
+* Any duplicate Type definitions will be merged by concatenating their fields
+* Any duplicate Schema definitions will be merged by concatenating their operations
 
 Combine several documents into a GraphqlSchema
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/code": "^4.0.0",
+    "@types/deepmerge": "^1.3.1",
     "@types/glob": "^5.0.30",
     "@types/graphql": "^0.9.0",
     "@types/lab": "^11.1.0",
@@ -35,6 +36,7 @@
     "@types/node": "^6.0.46",
     "@types/rimraf": "0.0.28",
     "code": "^4.0.0",
+    "deepmerge": "^1.5.0",
     "lab": "^11.2.1",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.5.4",
@@ -42,7 +44,8 @@
     "typescript": "^2.1.0"
   },
   "dependencies": {
-    "glob": "^7.0.5"
+    "glob": "^7.0.5",
+    "graphql-tools": "^1.1.0"
   },
   "peerDependencies": {
     "graphql": "^0.10.0"

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -10,7 +10,13 @@ import * as fs from 'fs'
 import { DocumentNode, GraphQLSchema } from 'graphql'
 import * as mkdirp from 'mkdirp'
 import * as rimraf from 'rimraf'
-import { combineDocuments, GraphQLLoaderError, loadDocument, loadSchema } from '../index'
+import {
+  combineDocuments,
+  executableSchemaFromModules,
+  GraphQLLoaderError,
+  loadDocument,
+  loadSchema,
+} from '../index'
 
 const glob = './fixtures/swapi/**/*.graphql'
 const userGlob = './fixtures/user/**/*.graphql'
@@ -158,12 +164,7 @@ describe('Schema Loader', () => {
 describe('Loading Document', () => {
   describe(`when loading glob with complete schema "${glob}"`, () => {
     let doc: DocumentNode
-    before((done) => {
-      loadDocument(glob).then((results) => {
-        doc = results
-        done()
-      })
-    })
+    before(() => loadDocument(glob).then((results) => doc = results))
 
     it('expect schema to be a graphql schema', (done) => {
       expect(doc).to.exist
@@ -177,15 +178,74 @@ describe('Combing Documents', () => {
   describe(`when loading glob with complete schema "${userGlob}"`, () => {
     let doc: DocumentNode
     let schema: GraphQLSchema
-    before((done) => {
-      Promise.all([
+    before(() => {
+      return Promise.all([
         loadDocument(userGlob),
         loadDocument(glob),
       ]).then((results) => {
         doc = results[0]
         schema = combineDocuments(results)
-        done()
       })
+    })
+
+    it('expect schema to be a graphql schema', (done) => {
+      expect(schema).to.exist
+      expect(schema).to.be.an.instanceof(GraphQLSchema)
+        done()
+    })
+  })
+      })
+
+describe('Build Executable Schema From GraphQL Modules', () => {
+  describe(`when preloading documents`, () => {
+    let doc: DocumentNode
+    let schema: GraphQLSchema
+    before(() => {
+      return Promise.all([
+        loadDocument(userGlob),
+        loadDocument(glob),
+      ]).then((results) => {
+        const modules = results.map((document) => ({ document, resolvers: {} }))
+        return executableSchemaFromModules(modules).then((execSchema) => schema = execSchema)
+      })
+    })
+
+    it('expect schema to be a graphql schema', (done) => {
+      expect(schema).to.exist
+      expect(schema).to.be.an.instanceof(GraphQLSchema)
+      done()
+    })
+  })
+
+  describe(`when providing array of functions`, () => {
+    let doc: DocumentNode
+    let schema: GraphQLSchema
+    before(() => {
+      return Promise.all([
+        loadDocument(userGlob),
+        loadDocument(glob),
+      ]).then((results) => {
+        const modules = results.map((document) => () => ({ document, resolvers: {} }))
+        return executableSchemaFromModules(modules).then((execSchema) => schema = execSchema)
+      })
+    })
+
+    it('expect schema to be a graphql schema', (done) => {
+      expect(schema).to.exist
+      expect(schema).to.be.an.instanceof(GraphQLSchema)
+      done()
+    })
+  })
+
+  describe(`when using promises`, () => {
+    let doc: DocumentNode
+    let schema: GraphQLSchema
+    before(() => {
+      const modules = [
+        () => loadDocument(userGlob).then((document) => ({ document, resolvers: {}})),
+        () => loadDocument(glob).then((document) => ({ document, resolvers: {}})),
+      ]
+      return executableSchemaFromModules(modules).then((execSchema) => schema = execSchema)
     })
 
     it('expect schema to be a graphql schema', (done) => {

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -191,7 +191,7 @@ describe('Combing Documents', () => {
     it('expect schema to be a graphql schema', (done) => {
       expect(schema).to.exist
       expect(schema).to.be.an.instanceof(GraphQLSchema)
-        done()
+      done()
     })
   })
       })


### PR DESCRIPTION
GraphQL modules are comprised of a document node and resolvers to provide away to decompose a GraphQL server into stand alone Node.js modules.  These modules expose a DocumentNode because document nodes are valid GraphQL segments that are not required to be a complete valid schema.

It is required that the combination of GraphQLModules results in a completely valid GraphQLSchema.
