### PR TITLE
Upgrade graphql package from 0.11.x to v14.0.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: node_js
 node_js:
+  - "9"
+  - "8"
+  - "7"
   - "6"
   - "5"
-  - "4"
 install:
-  - npm install
   - npm install graphql
+  - npm install
 
 script:
   - npm test

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/code": "^4.0.0",
     "@types/deepmerge": "^1.3.1",
     "@types/glob": "^5.0.30",
-    "@types/graphql": "^0.11.0",
+    "@types/graphql": "^0.13.3",
     "@types/mkdirp": "^0.5.2",
     "@types/node": "^6.0.46",
     "@types/rimraf": "2.0.2",
@@ -46,10 +46,10 @@
   "dependencies": {
     "deepmerge": "^2.0.1",
     "glob": "^7.1.2",
-    "graphql": "^0.11.7",
+    "graphql": "^0.13.2",
     "graphql-tools": "^2.18.0"
   },
   "peerDependencies": {
-    "graphql": "^0.9.0 || ^0.10.1 || ^0.11.0"
+    "graphql": "^0.9.0 || ^0.10.1 || ^0.11.0 || ^0.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/code": "^4.0.0",
     "@types/deepmerge": "^1.3.1",
     "@types/glob": "^5.0.30",
-    "@types/graphql": "^0.13.3",
+    "@types/graphql": "^14.0.0",
     "@types/mkdirp": "^0.5.2",
     "@types/node": "^6.0.46",
     "@types/rimraf": "2.0.2",
@@ -46,10 +46,10 @@
   "dependencies": {
     "deepmerge": "^2.0.1",
     "glob": "^7.1.2",
-    "graphql": "^0.13.2",
+    "graphql": "^14.0.2",
     "graphql-tools": "^2.18.0"
   },
   "peerDependencies": {
-    "graphql": "^0.9.0 || ^0.10.1 || ^0.11.0 || ^0.13.0"
+    "graphql": "^0.9.0 || ^0.10.1 || ^0.11.0 || ^14.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
  } from 'graphql'
 import { addResolveFunctionsToSchema } from 'graphql-tools'
 
-import * as Kind from 'graphql/language/kinds'
+import { Kind } from 'graphql/language/kinds'
 
 export class GraphQLLoaderError extends Error {
   public static zeroMatchError(glob: string): GraphQLLoaderError {


### PR DESCRIPTION
This upgrade brings some improvements to the schema definition language and improved error messages when the schema is invalid.

Note that some of the SDL changes are backwards-incompatible (i.e. existing .graphql files that are currently considered valid may be considered invalid after the upgrade). The adjustments needed are all relatively minor, but this may warrant a significant version bump for the next release of graphql-loader. You can read more about what changed in the release notes for [v0.12.0](https://github.com/graphql/graphql-js/releases/tag/v0.12.0), [v0.13.0](https://github.com/graphql/graphql-js/releases/tag/v0.13.0), and [v14.0.0](https://github.com/graphql/graphql-js/releases/tag/v14.0.0). These changes bring the SDL syntax closer in line with [the official specification](https://facebook.github.io/graphql/June2018/) and introduce some new language features (which is the main reason I'm interested in this upgrade).