### PR TITLE
Removed graphql from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "dependencies": {
     "deepmerge": "^2.0.1",
     "glob": "^7.1.2",
-    "graphql": "^0.11.7",
     "graphql-tools": "^2.18.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
The`graphql`dependency caused the following module clash error;
```
Error: Cannot use GraphQLObjectType "__Directive" from another module or realm.
```
I removed the dependency from the required `dependencies` while maintaining it as a `peerDependency`.